### PR TITLE
Use SSE4_CRC32 v4 to support node.js v4 and above

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-var crc = require('fast-crc32c')
+var crc = require('sse4_crc32')
 var crypto = require('crypto')
 var through = require('through2')
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "standard": "^5.1.0"
   },
   "dependencies": {
-    "fast-crc32c": "^1.0.0",
+    "sse4_crc32": "^4.1.0",
     "through2": "^2.0.0"
   },
   "standard": {

--- a/test.js
+++ b/test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 var assert = require('assert')
-var crc = require('fast-crc32c')
+var crc = require('sse4_crc32')
 var crypto = require('crypto')
 var fs = require('fs')
 


### PR DESCRIPTION
The use of the fast-crc32c library doesn't allow the hash-stream-validation
module to work on node.js v4+ due to its dependency on an older version that
does not use Nan v2 (which is required for node.js add-ons to work on node.js v4
and above).

This commit brings node.js v4 support to the hash-stream-validation libary.