### PR TITLE
docs: state that checksum is base64-encoded

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -58,4 +58,4 @@ The alogrithm to test the sum against ('crc32c' or 'md5').
 #### sum
 - Type: `String`
 
-The sum to validate.
+The base64-encoded sum to validate.


### PR DESCRIPTION
Tiny addition. Took me a bit to realize why my hex strings were failing to validate. :)