### PR TITLE
Drop through2

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ try {
 }
 
 var crypto = require('crypto')
-var through = require('through2')
+var { Transform } = require('stream')
 
 module.exports = function (cfg) {
   cfg = cfg || {}
@@ -33,7 +33,10 @@ module.exports = function (cfg) {
     done()
   }
 
-  var validationStream = through(onData, onFlush)
+  var validationStream = new Transform({
+    transform: onData,
+    flush: onFlush
+  })
 
   validationStream.test = function (algo, sum) {
     return hashes[algo] === sum

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ try {
 }
 
 var crypto = require('crypto')
-var { Transform } = require('stream')
+var { PassThrough } = require('stream')
 
 module.exports = function (cfg) {
   cfg = cfg || {}
@@ -33,7 +33,7 @@ module.exports = function (cfg) {
     done()
   }
 
-  var validationStream = new Transform({
+  var validationStream = new PassThrough({
     transform: onData,
     flush: onFlush
   })

--- a/package.json
+++ b/package.json
@@ -27,9 +27,6 @@
     "mocha": "^2.2.5",
     "standard": "^5.1.0"
   },
-  "dependencies": {
-    "through2": "^2.0.0"
-  },
   "standard": {
     "global": [
       "before",


### PR DESCRIPTION
Ref https://github.com/rvagg/through2#do-you-need-this

Node builtin stream.PassThrough handles same functionality just fine on
node 8+. Two dependencies (also readable-stream) can be dropped.